### PR TITLE
swc plugin support. It seems that swc has node binary imports which a…

### DIFF
--- a/django_deno/conf/settings.py
+++ b/django_deno/conf/settings.py
@@ -40,7 +40,7 @@ DENO_OUTPUT_MODULE_FORMATS.update(getattr(settings, 'DENO_OUTPUT_MODULE_FORMATS'
 DENO_ROLLUP_SERVE_OPTIONS = {
     'inlineFileMap': True,
     'relativePaths': True,
-    'sucrase': True,
+    'swc': True,
     'preserveEntrySignatures': False,
     'staticFilesResolver': 'serve',
     'withCache': True,
@@ -52,7 +52,7 @@ DENO_OUTPUT_MODULE_TYPE = getattr(settings, 'DENO_OUTPUT_MODULE_TYPE', 'module')
 DENO_ROLLUP_COLLECT_OPTIONS = {
     # 'relativePaths': True,
     'staticFilesResolver': 'collect',
-    'sucrase': True,
+    'swc': True,
     'terser': True,
     'bundles': getattr(settings, 'DENO_ROLLUP_BUNDLES', {}),
     'moduleFormat': DENO_OUTPUT_MODULE_FORMATS[DENO_OUTPUT_MODULE_TYPE],

--- a/django_deno/deno/deno.json
+++ b/django_deno/deno/deno.json
@@ -4,7 +4,6 @@
   "imports": {
     "rollup": "npm:rollup@2.79.2",
     "plugin-terser": "npm:@wwa/rollup-plugin-terser@1.1.2",
-    "plugin-sucrase": "npm:@rollup/plugin-sucrase@5.0.2",
-    "plugin-node-resolve": "npm:@rollup/plugin-node-resolve@15.3.0"
+    "plugin-swc": "npm:@rollup/plugin-swc@0.4.0"
   }
 }

--- a/django_deno/deno/rollup.ts
+++ b/django_deno/deno/rollup.ts
@@ -11,12 +11,10 @@ import { rollup } from "rollup";
 // import { SOURCEMAPPING_URL } from "rollup/sourceMappingURL.ts";
 import { RollupOutput } from "rollup";
 import { terser } from "plugin-terser";
-import sucraseImport from 'plugin-sucrase';
-import resolveImport from 'plugin-node-resolve';
+import swcImport from "plugin-swc";
 
 // https://github.com/denoland/deno/issues/17058#issuecomment-1353585286
-const sucrase = (sucraseImport as any as typeof sucraseImport.default);
-const resolve = (resolveImport as any as typeof resolveImport.default);
+const swc = (swcImport as any as typeof swcImport.default);
 
 import { isTypescript } from "./resolver/isTypescript.ts";
 import { parse } from "./resolver/parse.ts";
@@ -253,7 +251,7 @@ class InlineRollupOptions {
     relativePaths?: boolean;
     syntheticNamedExports?: string[];
     staticFilesResolver?: string;
-    sucrase?: boolean;
+    swc?: boolean;
     terser?: boolean;
     withCache?: boolean;
     writeAssets?: boolean;
@@ -382,21 +380,10 @@ class InlineRollup {
             resolveId: this.getStaticFilesResolver(),
         });
 
-        inputPlugins.push(
-            resolve({
-                extensions: ['.js', '.ts']
-            })
-        );
-
-        if (this.options.sucrase) {
+        if (this.options.swc) {
             // https://docs.deno.com/runtime/reference/ts_config_migration/
-            // make sure sucrase is supported for specified module format
-            inputPlugins.push(
-                sucrase({
-                    exclude: ['node_modules/**'],
-                    transforms: ['typescript']
-                })
-            );
+            // make sure swc is supported for specified module format
+            inputPlugins.push(swc());
         }
 
         if (this.options.terser) {

--- a/django_deno/process/base.py
+++ b/django_deno/process/base.py
@@ -15,6 +15,8 @@ class ExecDeno:
         "--allow-import",
         "--allow-net",
         "--allow-read",
+        # required by swc/core
+        "--allow-scripts",
         "--allow-sys",
         # "--unstable",
     ]


### PR DESCRIPTION
…re not supported by deno compile. Thus it works only when running server.ts manually.